### PR TITLE
remove dependency on async_to_sync and extra thread

### DIFF
--- a/muselsl/record.py
+++ b/muselsl/record.py
@@ -3,8 +3,9 @@ import pandas as pd
 import os
 from pylsl import StreamInlet, resolve_byprop
 from sklearn.linear_model import LinearRegression
-from time import time, sleep, strftime, gmtime
+from time import time, strftime, gmtime
 from .stream import find_muse
+from . import backends
 from .muse import Muse
 from . constants import LSL_SCAN_TIMEOUT, LSL_EEG_CHUNK, LSL_PPG_CHUNK, LSL_ACC_CHUNK, LSL_GYRO_CHUNK
 
@@ -152,7 +153,7 @@ def record_direct(duration, address, filename=None, backend='auto', interface=No
 
     while (time() - t_init) < duration:
         try:
-            sleep(1)
+            backends.sleep(1)
         except KeyboardInterrupt:
             break
 

--- a/muselsl/stream.py
+++ b/muselsl/stream.py
@@ -1,4 +1,4 @@
-from time import time, sleep
+from time import time
 from pylsl import StreamInfo, StreamOutlet
 from functools import partial
 import pygatt
@@ -162,7 +162,7 @@ def stream(address, backend='auto', interface=None, name=None, ppg_enabled=False
 
             while time() - muse.last_timestamp < AUTO_DISCONNECT_DELAY:
                 try:
-                    sleep(1)
+                    backends.sleep(1)
                 except KeyboardInterrupt:
                     muse.stop()
                     muse.disconnect()


### PR DESCRIPTION
This modifies the bleak implementation so that it pumps the event loop in the main thread.  The dependency on async_to_sync is removed.

I've found it can cause some troubles in other python environments to require the bluetooth implementation to run on a separate thread.